### PR TITLE
Allow instantiate to build cmdstanr-based packages without install as source

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Description: Similar to 'rstantools' for 'rstan',
   migrate from 'rstan' to the more modern 'cmdstanr'.
   Packages 'rstantools', 'cmdstanr', 'stannis', and
   'stanapi' are similar Stan clients with different objectives.
-Version: 0.2.3.9000
+Version: 0.2.2.9001
 License: MIT + file LICENSE
 URL: https://wlandau.github.io/instantiate/,
   https://github.com/wlandau/instantiate

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Description: Similar to 'rstantools' for 'rstan',
   migrate from 'rstan' to the more modern 'cmdstanr'.
   Packages 'rstantools', 'cmdstanr', 'stannis', and
   'stanapi' are similar Stan clients with different objectives.
-Version: 0.2.2.9000
+Version: 0.2.3.9000
 License: MIT + file LICENSE
 URL: https://wlandau.github.io/instantiate/,
   https://github.com/wlandau/instantiate

--- a/R/stan_package_model.R
+++ b/R/stan_package_model.R
@@ -20,7 +20,8 @@
 #' @param library Character of length 1 or `NULL`, library path
 #'   to look for the package with the built-in Stan model.
 #'   Passed to the `lib.loc` argument of `system.file()`.
-#' @param compile whether to compile the model.
+#' @param compile A boolean, whether to compile the model.
+#' @param ... Arguments passed to cmdstanr("cmdstan_model").
 #' @examples
 #' # Please see the documentation website of the {instantiate} package
 #' #   for examples.

--- a/R/stan_package_model.R
+++ b/R/stan_package_model.R
@@ -20,7 +20,10 @@
 #' @param library Character of length 1 or `NULL`, library path
 #'   to look for the package with the built-in Stan model.
 #'   Passed to the `lib.loc` argument of `system.file()`.
-#' @param compile A boolean, whether to compile the model.
+#' @param compile `TRUE` to compile the model and store the executable file
+#'    where the package is installed in `.libpaths()`. `FALSE` to
+#'    skip compilation and assume the model is already compiled,
+#'    which is usually the case.
 #' @param ... Arguments passed to cmdstanr("cmdstan_model").
 #' @examples
 #' # Please see the documentation website of the {instantiate} package

--- a/R/stan_package_model.R
+++ b/R/stan_package_model.R
@@ -20,6 +20,7 @@
 #' @param library Character of length 1 or `NULL`, library path
 #'   to look for the package with the built-in Stan model.
 #'   Passed to the `lib.loc` argument of `system.file()`.
+#' @param compile whether to compile the model.
 #' @examples
 #' # Please see the documentation website of the {instantiate} package
 #' #   for examples.
@@ -27,7 +28,8 @@ stan_package_model <- function(
   name,
   package,
   library = NULL,
-  cmdstan_install = Sys.getenv("CMDSTAN_INSTALL", unset = "")
+  cmdstan_install = Sys.getenv("CMDSTAN_INSTALL", unset = ""),
+  compile = FALSE
 ) {
   stan_assert_cmdstanr()
   stan_assert(name, is.character(.), !anyNA(.), nzchar(.))
@@ -71,6 +73,6 @@ stan_package_model <- function(
   cmdstanr("cmdstan_model")(
     stan_file = stan_file,
     exe_file = exe_file,
-    compile = FALSE
+    compile = compile
   )
 }

--- a/R/stan_package_model.R
+++ b/R/stan_package_model.R
@@ -29,7 +29,8 @@ stan_package_model <- function(
   package,
   library = NULL,
   cmdstan_install = Sys.getenv("CMDSTAN_INSTALL", unset = ""),
-  compile = FALSE
+  compile = FALSE,
+  ...
 ) {
   stan_assert_cmdstanr()
   stan_assert(name, is.character(.), !anyNA(.), nzchar(.))
@@ -73,6 +74,7 @@ stan_package_model <- function(
   cmdstanr("cmdstan_model")(
     stan_file = stan_file,
     exe_file = exe_file,
-    compile = compile
+    compile = compile,
+    ...
   )
 }


### PR DESCRIPTION
# Prework

* [ x] I understand and agree to the Contributor Code of Conduct.
* [ x] I have already submitted a GitHub Discussion topic to discuss my idea with the maintainer.

# Related GitHub issues and pull requests

https://github.com/wlandau/instantiate/discussions/25#discussioncomment-10728665

# Summary

Hello,

I have prepared a pull request that enables `instantiate` to build cmdstanr-based packages without requiring users to install the package from the source (```install.packages(..., type = "source")```). This enhancement allows packages like sccomp (linked below) to be installed and compiled just like any other R package, simplifying the installation process for end-users.

https://github.com/MangiolaLaboratory/sccomp/tree/cmdstanr

For example, in the sccomp package, I have implemented the following:

	•	The models are compiled once and cached when needed, avoiding the need to install from the source.
	•	The process leverages several utilities from instantiate to handle the compilation efficiently, including stan_package_model() and stan_package_compile().


The PR would be very light, from here

https://github.com/stemangiola/instantiate

This would be the only simple change

<img width="1245" alt="image" src="https://github.com/user-attachments/assets/c990cdf9-ced9-45ac-814f-6c03e9082fd5">

This is how I am using this edited function

```r
    mod = instantiate::stan_package_model(
      name = name, 
      package = "sccomp", 
      compile = TRUE,
      cpp_options = list(stan_threads = TRUE)
    )
 ```

Thanks for considering this PR
