### PR TITLE
Add include_paths argument to stan_package_model()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,4 +45,4 @@ Encoding: UTF-8
 Language: en-US
 Config/testthat/edition: 3
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Omit `stan_file` from `cmdstan_model()` when `compile` is `FALSE` (#28, @lcgodoy).
 * Emphasize incompatibility with `pkgload::load_all()` (#29, @toddmccready).
+* Add `include_paths` argument to `stan_package_model()` (#33, @t-momozaki).
 
 # instantiate 0.2.3
 

--- a/R/stan_package_model.R
+++ b/R/stan_package_model.R
@@ -24,6 +24,8 @@
 #'    where the package is installed in `.libpaths()`. `FALSE` to
 #'    skip compilation and assume the model is already compiled,
 #'    which is usually the case.
+#' @param include_paths Argument to `cmdstanr::cmdstan_model()`
+#'   to control model compilation.
 #' @param ... Named arguments passed via `cmdstanr::cmdstan_model()`
 #'    to the `compile()` method of the CmdStan model object.
 #' @examples
@@ -35,6 +37,7 @@ stan_package_model <- function(
   library = NULL,
   cmdstan_install = Sys.getenv("CMDSTAN_INSTALL", unset = ""),
   compile = FALSE,
+  include_paths = NULL,
   ...
 ) {
   stan_assert_cmdstanr()
@@ -89,12 +92,14 @@ stan_package_model <- function(
     cmdstanr("cmdstan_model")(
       stan_file = stan_file,
       compile = compile,
+      include_paths = include_paths,
       ...
     )
   } else {
     cmdstanr("cmdstan_model")(
       exe_file = exe_file,
       compile = compile,
+      include_paths = include_paths,
       ...
     )
   }

--- a/man/stan_package_model.Rd
+++ b/man/stan_package_model.Rd
@@ -10,6 +10,7 @@ stan_package_model(
   library = NULL,
   cmdstan_install = Sys.getenv("CMDSTAN_INSTALL", unset = ""),
   compile = FALSE,
+  include_paths = NULL,
   ...
 )
 }
@@ -49,6 +50,9 @@ was installed.
 where the package is installed in \code{.libpaths()}. \code{FALSE} to
 skip compilation and assume the model is already compiled,
 which is usually the case.}
+
+\item{include_paths}{Argument to \code{cmdstanr::cmdstan_model()}
+to control model compilation.}
 
 \item{...}{Named arguments passed via \code{cmdstanr::cmdstan_model()}
 to the \code{compile()} method of the CmdStan model object.}

--- a/tests/testthat/test-stan_package_model.R
+++ b/tests/testthat/test-stan_package_model.R
@@ -63,6 +63,40 @@ stan_test("stan_package_model(compile = TRUE)", {
   expect_true(is.data.frame(fit$summary()))
 })
 
+stan_test("stan_package_model(include_paths = ...)", {
+  skip_cmdstan()
+  path <- "example"
+  stan_package_create(path = path)
+  stan_package_configure(path = path)
+  temporary_library <- "library"
+  dir.create(temporary_library)
+  tmp <- utils::capture.output(
+    install.packages(
+      pkgs = path,
+      lib = temporary_library,
+      type = "source",
+      repos = NULL,
+      quiet = TRUE
+    )
+  )
+  stan_dir <- file.path(temporary_library, "example", "bin", "stan")
+  model <- stan_package_model(
+    name = "bernoulli",
+    package = "example",
+    library = temporary_library,
+    include_paths = stan_dir
+  )
+  tmp <- utils::capture.output(
+    fit <- model$sample(
+      data = list(N = 10, y = c(1, 0, 1, 0, 1, 0, 0, 0, 0, 0)),
+      refresh = 0,
+      iter_warmup = 2000,
+      iter_sampling = 4000
+    )
+  )
+  expect_true(is.data.frame(fit$summary()))
+})
+
 stan_test("stan_package_model() with deprecated inst", {
   skip_cmdstan()
   path <- "example"


### PR DESCRIPTION
## Summary

- Adds a formal `include_paths` argument to `stan_package_model()`, passed through to `cmdstanr::cmdstan_model()`
- Follows the same pattern as the existing `include_paths` argument in `stan_package_compile()`
- Fixes the issue where Stan files with `#include` directives cause runtime errors when cmdstanr re-parses the Stan file

Closes #33

## Changes

- `R/stan_package_model.R`: Added `include_paths = NULL` parameter and forwarded it to both `cmdstanr::cmdstan_model()` call sites
- `man/stan_package_model.Rd`: Regenerated via `devtools::document()`
- `NEWS.md`: Added entry for the new argument
- `tests/testthat/test-stan_package_model.R`: Added test for `include_paths` usage