### PR TITLE
replace outdated Stan repo url

### DIFF
--- a/R/utils_assert.R
+++ b/R/utils_assert.R
@@ -118,7 +118,7 @@ stan_assert_cmdstanr <- function() {
         "The {cmdstanr} package is required in order to install",
         "CmdStan and run Stan models. Please install it manually using",
         "install.packages(pkgs = \"cmdstanr\",",
-        "repos = c(\"https://mc-stan.org/r-packages/\", getOption(\"repos\"))"
+        "repos = c(\"https://stan-dev.r-universe.dev/\", getOption(\"repos\"))"
       )
     ),
     error = function(e) {

--- a/README.Rmd
+++ b/README.Rmd
@@ -32,7 +32,7 @@ The website at <https://wlandau.github.io/instantiate/> includes a [function ref
 
 The `instantiate` package depends on the R package [`CmdStanR`](https://mc-stan.org/cmdstanr/) and the command line tool [`CmdStan`](https://mc-stan.org/users/interfaces/cmdstan), so it is important to follow these stages in order:
 
-1. Install the R package [`CmdStanR`](https://mc-stan.org/cmdstanr/). [`CmdStanR`](https://mc-stan.org/cmdstanr/) is not on CRAN, so the recommended way to install it is `install.packages("cmdstanr", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))`.
+1. Install the R package [`CmdStanR`](https://mc-stan.org/cmdstanr/). [`CmdStanR`](https://mc-stan.org/cmdstanr/) is not on CRAN, so the recommended way to install it is `install.packages("cmdstanr", repos = c("https://stan-dev.r-universe.dev/", getOption("repos")))`.
 2. Optional: set environment variables `CMDSTAN_INSTALL` and/or `CMDSTAN` to manage the  [`CmdStan`](https://mc-stan.org/users/interfaces/cmdstan) installation. See the "Administering CmdStan" section below for details.
 3. Install `instantiate` using one of the R commands below.
 
@@ -191,11 +191,11 @@ run_bernoulli_model <- function(y, ...) {
 
 ## Development
 
-1. In your package `DESCRIPTION` file, list <https://mc-stan.org/r-packages/> in the `Additional_repositories:` field ([example in `brms`](https://github.com/paul-buerkner/brms/blob/5c09251daabd5416e3d47004cc6c62816dc53cfa/DESCRIPTION#L95-L96)). This step is only necessary while [`cmdstanr`](https://mc-stan.org/cmdstanr/) is not yet on CRAN.
+1. In your package `DESCRIPTION` file, list <https://stan-dev.r-universe.dev/> in the `Additional_repositories:` field ([example in `brms`](https://github.com/paul-buerkner/brms/blob/5c09251daabd5416e3d47004cc6c62816dc53cfa/DESCRIPTION#L95-L96)). This step is only necessary while [`cmdstanr`](https://mc-stan.org/cmdstanr/) is not yet on CRAN.
 
 ```
 Additional_repositories:
-    https://mc-stan.org/r-packages/
+    https://stan-dev.r-universe.dev/
 ```
 
 2. In your package `DESCRIPTION` and `NAMESPACE` files, import the `instantiate` package and function `stan_package_model()`.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ important to follow these stages in order:
 1.  Install the R package [`CmdStanR`](https://mc-stan.org/cmdstanr/).
     [`CmdStanR`](https://mc-stan.org/cmdstanr/) is not on CRAN, so the
     recommended way to install it is
-    `install.packages("cmdstanr", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))`.
+    `install.packages("cmdstanr", repos = c("https://stan-dev.r-universe.dev/", getOption("repos")))`.
 2.  Optional: set environment variables `CMDSTAN_INSTALL` and/or
     `CMDSTAN` to manage the
     [`CmdStan`](https://mc-stan.org/users/interfaces/cmdstan)
@@ -245,7 +245,7 @@ run_bernoulli_model <- function(y, ...) {
 ## Development
 
 1.  In your package `DESCRIPTION` file, list
-    <https://mc-stan.org/r-packages/> in the `Additional_repositories:`
+    <https://stan-dev.r-universe.dev/> in the `Additional_repositories:`
     field ([example in
     `brms`](https://github.com/paul-buerkner/brms/blob/5c09251daabd5416e3d47004cc6c62816dc53cfa/DESCRIPTION#L95-L96)).
     This step is only necessary while
@@ -254,7 +254,7 @@ run_bernoulli_model <- function(y, ...) {
 <!-- -->
 
     Additional_repositories:
-        https://mc-stan.org/r-packages/
+        https://stan-dev.r-universe.dev/
 
 2.  In your package `DESCRIPTION` and `NAMESPACE` files, import the
     `instantiate` package and function `stan_package_model()`.

--- a/inst/example/DESCRIPTION
+++ b/inst/example/DESCRIPTION
@@ -11,7 +11,7 @@ Depends:
 Imports:
   instantiate
 Additional_repositories:
-  https://mc-stan.org/r-packages/
+  https://stan-dev.r-universe.dev/
 SystemRequirements: CmdStan (https://mc-stan.org/users/interfaces/cmdstan)
 Encoding: UTF-8
 LazyData: true

--- a/inst/example/github/workflows/check.yaml
+++ b/inst/example/github/workflows/check.yaml
@@ -29,14 +29,14 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
-          extra-repositories: 'https://mc-stan.org/r-packages/'
+          extra-repositories: 'https://stan-dev.r-universe.dev/'
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
       - name: Install CmdStan
         shell: Rscript {0}
         run: |
-          install.packages("cmdstanr", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
+          install.packages("cmdstanr", repos = c("https://stan-dev.r-universe.dev/", getOption("repos")))
           cmdstanr::check_cmdstan_toolchain(fix = TRUE)
           cmdstanr::install_cmdstan()
 


### PR DESCRIPTION
# Prework

* [x] I understand and agree to the Contributor Code of Conduct.
* [x] I have already submitted a GitHub Discussion topic to discuss my idea with the maintainer.

(I submitted an issue, not a Discussion topic) 

# Related GitHub issues and pull requests

* Ref: #38

# Summary

The old https://mc-stan.org/r-packages/ should be replaced with the R universe URL to make sure future releases of cmdstanr are found. Although I suppose R multiverse would also be a possibility? 